### PR TITLE
Quick fix to "ambiguous use" error

### DIFF
--- a/json.swift
+++ b/json.swift
@@ -23,7 +23,7 @@ extension JSON {
     /// pases string to the JSON object
     public class func parse(str:String)->JSON {
         var err:NSError?
-        let enc = NSUTF8StringEncoding
+        let enc:NSStringEncoding = NSUTF8StringEncoding
         var obj:AnyObject? = NSJSONSerialization.JSONObjectWithData(
             str.dataUsingEncoding(enc), options:nil, error:&err
         )


### PR DESCRIPTION
Thanks for this library! I was getting an error on this line about "Ambigious use of 'NSUTFStringEncoding'" (using Xcode 6 beta 4). This should make it unambiguous.
