### PR TITLE
remove extra trailing ! for Swift 1.0

### DIFF
--- a/json.swift
+++ b/json.swift
@@ -52,7 +52,7 @@ extension JSON {
     }
     /// constructs JSON object from the content of URL
     public convenience init(url:String) {
-        self.init(nsurl:NSURL(string:url)!)
+        self.init(nsurl:NSURL(string:url))
     }
     /// fetch the JSON string from URL in the string
     public class func fromURL(url:String) -> JSON {
@@ -326,7 +326,7 @@ extension JSON : Printable {
             )
             return NSString(
                 data:data!, encoding:NSUTF8StringEncoding
-            )!
+            )
         }
     }
     public var description:String { return toString() }


### PR DESCRIPTION
Unnecessary suffix ! causes compilation errors in Swift version 1.0 (swift-600.0.51.4) / Xcode 6.0.1.
